### PR TITLE
use `--no-build-isolation` to fix version seen by `pip`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,16 @@ source:
 
 build:
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   host:
     - python >=3.6
     - pip
+    - setuptools >=45
+    - wheel
+    - setuptools_scm >=6.2
   run:
     - python >=3.6
     - matplotlib-base >=2.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

The current `wxmplot` package in conda is seen by `pip` as version `0.0.0` rather than it's version.
This is most likely due to the use of `setuptools_scm`'s `write_to` which is ["broken for usage from a sdist"](https://setuptools-scm.readthedocs.io/en/latest/config/) here:

https://github.com/newville/wxmplot/blob/master/pyproject.toml#L6

This is causing issues when mixing pip and conda installs: If a package installed by `pip` requires a minimal version of `wxmplot` then it will re-install it even if the version already installed fits the constraint.

This PR proposes to fix this issue by using the `--no-build-isolation` option.

<!--
Please add any other relevant info below:
-->
